### PR TITLE
[bitnami/mlflow] feat: 🔒 make S3 secret optional

### DIFF
--- a/bitnami/mlflow/Chart.yaml
+++ b/bitnami/mlflow/Chart.yaml
@@ -43,4 +43,4 @@ name: mlflow
 sources:
 - https://github.com/bitnami/containers/tree/main/bitnami/mlflow
 - https://github.com/mlflow/mlflow
-version: 0.6.0
+version: 0.7.0

--- a/bitnami/mlflow/README.md
+++ b/bitnami/mlflow/README.md
@@ -468,6 +468,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ----------------------------------------- | ------------------------------------------------------------------ | --------------- |
 | `externalS3.host`                         | External S3 host                                                   | `""`            |
 | `externalS3.port`                         | External S3 port number                                            | `443`           |
+| `externalS3.useCredentialsInSecret`       | Whether to use a secret to store the S3 credentials                | `true`          |
 | `externalS3.accessKeyID`                  | External S3 access key ID                                          | `""`            |
 | `externalS3.accessKeySecret`              | External S3 access key secret                                      | `""`            |
 | `externalS3.existingSecret`               | Name of an existing secret resource containing the S3 credentials  | `""`            |

--- a/bitnami/mlflow/templates/tracking/deployment.yaml
+++ b/bitnami/mlflow/templates/tracking/deployment.yaml
@@ -173,6 +173,7 @@ spec:
                   key: {{ include "mlflow.v0.database.passwordKey" . | quote }}
             {{- end }}
             {{- if (include "mlflow.v0.s3.enabled" .) }}
+            {{- if .Values.externalS3.useCredentialsInSecret }}
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
@@ -183,6 +184,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "mlflow.v0.s3.secretName" . }}
                   key: {{ include "mlflow.v0.s3.secretAccessKeyKey" . | quote }}
+            {{- end }}
             - name: MLFLOW_S3_ENDPOINT_URL
               value: {{ printf "%s://%s:%v" (include "mlflow.v0.s3.protocol" .) (include "mlflow.v0.s3.host" .) (include "mlflow.v0.s3.port" .) | quote }}
             {{- end }}

--- a/bitnami/mlflow/templates/tracking/externals3-secret.yaml
+++ b/bitnami/mlflow/templates/tracking/externals3-secret.yaml
@@ -3,7 +3,12 @@ Copyright VMware, Inc.
 SPDX-License-Identifier: APACHE-2.0
 */}}
 
-{{- if and .Values.tracking.enabled (not .Values.minio.enabled) (not .Values.externalS3.existingSecret) }}
+{{- if and
+  .Values.tracking.enabled
+  .Values.externalS3.useCredentialsInSecret
+  (not .Values.minio.enabled)
+  (not .Values.externalS3.existingSecret)
+}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/bitnami/mlflow/values.schema.json
+++ b/bitnami/mlflow/values.schema.json
@@ -2057,6 +2057,11 @@
                     "description": "External S3 port number",
                     "default": 443
                 },
+                "useCredentialsInSecret": {
+                    "type": "boolean",
+                    "description": "Whether to use a secret to store the S3 credentials",
+                    "default": true
+                },
                 "accessKeyID": {
                     "type": "string",
                     "description": "External S3 access key ID",

--- a/bitnami/mlflow/values.yaml
+++ b/bitnami/mlflow/values.yaml
@@ -1368,6 +1368,7 @@ minio:
 ## All of these values are only used when minio.enabled is set to false
 ## @param externalS3.host External S3 host
 ## @param externalS3.port External S3 port number
+## @param externalS3.useCredentialsInSecret Whether to use a secret to store the S3 credentials
 ## @param externalS3.accessKeyID External S3 access key ID
 ## @param externalS3.accessKeySecret External S3 access key secret
 ## @param externalS3.existingSecret Name of an existing secret resource containing the S3 credentials
@@ -1380,6 +1381,7 @@ minio:
 externalS3:
   host: ""
   port: 443
+  useCredentialsInSecret: true
   accessKeyID: ""
   accessKeySecret: ""
   existingSecret: ""


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This patch introduces a new value `externalS3.useCredentialsInSecret` that lets users opt out of setting AWS credentials for connecting to S3 using a kubernetes secret.

When this value is set to `true` (the default), the chart behaves in the exact same way as before, creating and/or referencing a secret for setting the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` variables.

When this value is set to `false`, `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are not set and no secret is created and/or referenced.

### Benefits

Previously, enabling external S3 meant that the chart was setting the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables with values from a kubernetes secret. However, users may want to use other means of providing these credentials, e.g. on EKS, where it's possible to use a web identity token file, e.g. using [IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html). However, if `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are set, they will take precedence, because they come first in the credentials provider chain.

### Possible drawbacks

None that I am immediately aware of.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
None

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
